### PR TITLE
dotenv for keys + hot reloading of outage models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ build
 serve_images
 val2014
 vqa_examples
+
+.env
+
+outage_models.json

--- a/fastchat/serve/gradio_block_arena_vision_anony.py
+++ b/fastchat/serve/gradio_block_arena_vision_anony.py
@@ -54,7 +54,7 @@ from fastchat.serve.gradio_block_arena_anony import (
     SAMPLING_WEIGHTS,
     BATTLE_TARGETS,
     SAMPLING_BOOST_MODELS,
-    OUTAGE_MODELS,
+    # OUTAGE_MODELS,
 )
 from fastchat.serve.gradio_block_arena_vision import (
     set_invisible_image,


### PR DESCRIPTION
- Move API keys to a dotenv file
- Make modification of outage models possible without reloading